### PR TITLE
Implemented skclust support and wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,211 @@
 .DS_Store
 Icon?
+notebooks/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 #### Completed:
-
+* 2026.1.12 - Removed `umap_fuzzy_simplical_set_graph`
+* 2026.1.12 - `ClusteredNetwork` and `BiDirectionalClusteredNetwork` wrap `skclust.graph.ConsensusLeidenClustering` which properly implements multi-threaded behavior
+* 2026.1.12 - Moved `n_jobs` from `.fit` to `__init__` in `ClusteredNetwork` and `BiDirectionalClusteredNetwork`
+* 2026.1.12 - Removed `cluster_membership_cooccurrence` and replaced with `skclust.graph.cluster_membership_cooccurrence`
+* 2026.1.12 - Removed `community_detection` and replaced with `skclust.graph.ConsensusLeidenClustering` 
+* 2026.1.12 - Added `skclust>=2026.1.9` dependency
+* 2026.1.12 - Removed `joblib` dependency
 * 2025.7.8 - Fixed `edge_cluster_cooccurrence` error in `BiDirectionalClusteredNetwork`
 * 2025.3.4 - Optimizing conversion between `pd.Series` and `igraph` in `convert_network`
 * 2025.3.4 - Added `pairwise_log_ratio` function to compute pairwise log ratios between components

--- a/ensemble_networkx.egg-info/PKG-INFO
+++ b/ensemble_networkx.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
-Metadata-Version: 2.1
+Metadata-Version: 2.4
 Name: ensemble_networkx
-Version: 2025.7.8
+Version: 2026.1.12
 Summary: Ensemble networks in Python
 Home-page: https://github.com/jolespin/ensemble_networkx
 Author: Josh L. Espinoza
@@ -17,4 +17,11 @@ Requires-Dist: soothsayer_utils>=2022.6.24
 Requires-Dist: compositional>=2023.8.28
 Requires-Dist: scikit-learn>=1.0
 Requires-Dist: leidenalg
-Requires-Dist: joblib
+Requires-Dist: skclust>=2026.1.9
+Dynamic: author
+Dynamic: author-email
+Dynamic: home-page
+Dynamic: license
+Dynamic: license-file
+Dynamic: requires-dist
+Dynamic: summary

--- a/ensemble_networkx.egg-info/requires.txt
+++ b/ensemble_networkx.egg-info/requires.txt
@@ -8,4 +8,4 @@ soothsayer_utils>=2022.6.24
 compositional>=2023.8.28
 scikit-learn>=1.0
 leidenalg
-joblib
+skclust>=2026.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ soothsayer_utils>=2022.6.24
 compositional>=2023.8.28
 scikit-learn>=1.0
 leidenalg
-joblib
+skclust>=2026.1.9


### PR DESCRIPTION
* 2026.1.12 - Removed `umap_fuzzy_simplical_set_graph`
* 2026.1.12 - `ClusteredNetwork` and `BiDirectionalClusteredNetwork` wrap `skclust.graph.ConsensusLeidenClustering` which properly implements multi-threaded behavior
* 2026.1.12 - Moved `n_jobs` from `.fit` to `__init__` in `ClusteredNetwork` and `BiDirectionalClusteredNetwork`
* 2026.1.12 - Removed `cluster_membership_cooccurrence` and replaced with `skclust.graph.cluster_membership_cooccurrence`
* 2026.1.12 - Removed `community_detection` and replaced with `skclust.graph.ConsensusLeidenClustering` 
* 2026.1.12 - Added `skclust>=2026.1.9` dependency
* 2026.1.12 - Removed `joblib` dependency